### PR TITLE
update to latest upstream manifest

### DIFF
--- a/io.gitlab.construo.construo.json
+++ b/io.gitlab.construo.construo.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.gitlab.construo.construo",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "20.08",
     "sdk": "org.freedesktop.Sdk",
     "rename-icon": "construo",
     "rename-desktop-file": "construo.x11.desktop",
@@ -11,6 +11,51 @@
         "--socket=x11"
     ],
     "modules": [
+        {
+            "name": "jsoncpp",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_PREFIX:PATH=/app"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz",
+                    "sha256": "c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6"
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/*.a",
+                "/lib/pkgconfig"
+            ]
+        },
+        {
+            "name": "fmt",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/fmtlib/fmt/archive/6.1.2.tar.gz",
+                    "sha256": "1cafc80701b746085dddf41bd9193e6d35089e1c6ec1940e037fcb9c98f62365"
+                }
+            ],
+            "buildsystem": "cmake-ninja",
+            "builddir": "true",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DFMT_TEST=OFF"
+            ],
+            "cleanup": [
+                "*.a",
+                "/bin",
+                "/include",
+                "/lib/cmake",
+                "/lib/pkgconfig",
+                "/share"
+            ]
+        },
         {
             "name": "construo",
             "buildsystem": "cmake-ninja",
@@ -22,7 +67,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.com/construo/construo.git",
-                    "commit": "5092c7e782b04d30b68fae09bee0f2ea82d5e066"
+                    "commit": "d627f04705477f2f3ddf6637c9a4e60b702766cd"
                 }
             ]
         }


### PR DESCRIPTION
the 1.6 platform is significantly out of security support, which isn't the end of the world given the scope of the game and the sandoxing but not many people still have it installed and it's a download.

This updates to the latest flatpak manifest in the upstream project, pulling in the shared modules and pointing to a specific commit.